### PR TITLE
Added OpenShift cluster login via token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ OC_ALIAS=example-cluster
 OC_URL=https://dev-api.openshift.example.com:6443
 OC_USER=kubeadmin
 OC_PASSWORD=my-secret-passwd-sauce
+OC_TOKEN=my-token # to be used instead of OC_USER and OC_PASSWORD
 
 # Kafka
 KAFKA_OPERATOR=strimzi # E.g. strimzi or amq-streams

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,13 @@ export $(shell sed 's/=.*//' ${ENV_FILE})
 # NOTE: the actual commands here have to be indented by TABs
 .PHONY: oc_login
 oc_login:
+ifdef OC_TOKEN
+	$(info **** Using OC_TOKEN for login ****)
+	oc login ${OC_URL} --token=${OC_TOKEN}
+else
+	$(info **** Using OC_USER and OC_PASSWORD for login ****)
 	oc login ${OC_URL} -u ${OC_USER} -p ${OC_PASSWORD} --insecure-skip-tls-verify=true
+endif
 
 datagrid: oc_login
 	./datagrid/deploy.sh


### PR DESCRIPTION
With this PR, you can login the OpenShift cluster using a token instead of username/password so setting the `OC_TOKEN` env var instead of both `OC_USER` and `OC_PASSWORD`.